### PR TITLE
pin tencentcloud-sdk-python-tmt to <3.1 to prevent import breakage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "onnx",
     "onnxruntime",
     "opencv-python-headless",
-    "tencentcloud-sdk-python-tmt",
+    "tencentcloud-sdk-python-tmt<3.1",
     "pdfminer-six==20250416",
     "gradio_pdf>=0.0.21",
     "pikepdf",


### PR DESCRIPTION
The `tencentcloud-sdk-python-tmt` package removed `TextTranslateRequest` in version 3.1.x, causing `pdf2zh/translator.py` to fail on fresh installs with:

```
ImportError: cannot import name 'TextTranslateRequest' from 'tencentcloud_sdk_tmt.models'
```

This PR adds an upper bound constraint (`<3.1`) to maintain compatibility with the current import pattern while allowing the package to receive security updates within the 3.0.x series.

I have been following your project's impressive development velocity and would welcome the opportunity for mutual technical exchange between our respective research directions.