### PR TITLE
fix(ollama): surface real error when server returns a dict error payload

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -333,6 +333,15 @@ class OllamaTranslator(BaseTranslator):
             messages=self.prompt(text, self.prompt_template),
             options=self.options,
         )
+        # Some ollama server versions return an error payload as HTTP 200
+        # (e.g. {"error": "model ... not found"}), in which case client.chat()
+        # yields that dict instead of raising. Accessing .message on it would
+        # raise a cryptic "AttributeError: 'dict' object has no attribute
+        # 'message'"; surface the real error instead.
+        if isinstance(response, dict):
+            raise RuntimeError(
+                f"Ollama API error: {response.get('error', response)}"
+            )
         content = self._remove_cot_content(response.message.content or "")
         return content.strip()
 

--- a/test/test_translator.py
+++ b/test/test_translator.py
@@ -220,5 +220,33 @@ class TestOllamaTranslator(unittest.TestCase):
         )
 
 
+    def test_ollama_do_translate_dict_error_response(self):
+        # Regression test for #981: some ollama servers return an error payload
+        # as HTTP 200 (e.g. {"error": "model ... not found"}), in which case
+        # client.chat() yields that dict instead of raising. Accessing .message
+        # on it used to raise a cryptic
+        # "AttributeError: 'dict' object has no attribute 'message'".
+        # do_translate must surface the real error instead.
+        translator = OllamaTranslator("en", "zh", "gemma2", ignore_cache=True)
+        with mock.patch.object(
+            translator.client,
+            "chat",
+            return_value={"error": "model 'gemma2' not found"},
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                translator.do_translate("hello")
+            self.assertIn("model 'gemma2' not found", str(ctx.exception))
+
+    def test_ollama_do_translate_success_path(self):
+        # The normal (non-dict) response path must keep working unchanged.
+        translator = OllamaTranslator("en", "zh", "gemma2", ignore_cache=True)
+        good_response = mock.Mock()
+        good_response.message.content = "你好"
+        with mock.patch.object(
+            translator.client, "chat", return_value=good_response
+        ):
+            self.assertEqual(translator.do_translate("hello"), "你好")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# PR #981 — ollama: surface real error when server returns a dict error payload

## 背景
issue #981 报：用 `ollama:cogito:32b` 翻译时，converter.py:357 反复刷
`ERROR:pdf2zh.converter:'dict' object has no attribute 'message'`，翻译直接失败。

## 根因
`OllamaTranslator.do_translate` 里：
```python
response = self.client.chat(...)
content = self._remove_cot_content(response.message.content or "")
```
部分 ollama 服务在出错时（模型不存在、请求参数不合法等）会把错误体
`{"error": "..."}` 作为 **HTTP 200** 返回，此时 `client.chat()` 不抛异常
而是原样返回这个 dict。紧接着 `response.message` 就炸出
`AttributeError: 'dict' object has no attribute 'message'`——正是 issue 里
那条 cryptic 报错，真实错误（模型不存在等）被彻底淹没。

## 修复
在 `do_translate` 取 `response.message` 前加一层类型检查：拿到 dict 说明是
API 错误体，直接把里面的 error 字段包成清晰的 `RuntimeError` 抛出，让上层
（converter 的 worker + tenacity retry）能看到真实原因、并按重试/失败逻辑处理，
而不是撞一堵 `AttributeError`。

## 测试
`test/test_translator.py` 新增 2 个回归测试（挂在现有 `TestOllamaTranslator` 类里，
复用其 `mock.patch.object(translator.client, "chat", ...)` 风格，不连真实服务）：
- `test_ollama_do_translate_dict_error_response`：mock chat 返回
  `{"error": "model 'gemma2' not found"}`，断言抛 `RuntimeError` 且信息含真实错误
- `test_ollama_do_translate_success_path`：mock chat 返回正常 response 对象，
  断言成功路径不变（防回归）

## 验证（红绿对照）
- 原始代码：`test_ollama_do_translate_dict_error_response` 报
  `AttributeError: 'dict' object has no attribute 'message'`（红，复现 issue）
- 修复版：两条测试全绿；成功路径红绿两边都过（无回归）

改动：`pdf2zh/translator.py`（+9 行防护）、`test/test_translator.py`（+2 回归测试）。
