### PR TITLE
fix: translate text in abandoned layout regions

### DIFF
--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -32,6 +32,12 @@ from pdf2zh.config import ConfigManager
 from babeldoc.assets.assets import get_font_and_metadata
 
 NOTO_NAME = "noto"
+LAYOUT_EXCLUDED_CLASSES = (
+    "figure",
+    "table",
+    "isolate_formula",
+    "formula_caption",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +141,7 @@ def translate_patch(
             # kdtree 是不可能 kdtree 的，不如直接渲染成图片，用空间换时间
             box = np.ones((pix.height, pix.width))
             h, w = box.shape
-            vcls = ["abandon", "figure", "table", "isolate_formula", "formula_caption"]
+            vcls = LAYOUT_EXCLUDED_CLASSES
             for i, d in enumerate(page_layout.boxes):
                 if page_layout.names[int(d.cls)] not in vcls:
                     x0, y0, x1, y1 = d.xyxy.squeeze()

--- a/test/test_layout_classes.py
+++ b/test/test_layout_classes.py
@@ -1,0 +1,8 @@
+from pdf2zh.high_level import LAYOUT_EXCLUDED_CLASSES
+
+
+def test_abandon_regions_are_not_excluded_from_text_translation():
+    assert "abandon" not in LAYOUT_EXCLUDED_CLASSES
+    assert {"figure", "table", "isolate_formula", "formula_caption"} == set(
+        LAYOUT_EXCLUDED_CLASSES
+    )


### PR DESCRIPTION
## Summary

Text in `abandon` layout regions was treated as protected content and could be omitted from translation. Remove `abandon` from the protected layout classes while keeping figure, table, and formula regions excluded.

Fixes #1176

## Reviewers

@reycn @soukouki @samqin123