### PR TITLE
feat: experimental ocr with paragraph regrouping and adaptive typesetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,29 @@ For docker deployment on cloud service:
 
 <h2 id="usage">4. Technical Details</h2>
 
+### Experimental automatic OCR (fast mode)
+
+Fast mode automatically runs local OCR on selected image-only pages before
+translation. Native text, existing OCR layers, and blank pages are skipped;
+the original pages in dual output remain unchanged. Install with
+`pip install 'pdf2zh[ocr]'` (or `pip install -e '.[ocr]'` from this checkout).
+The first scanned page downloads the requested language data from Tesseract's
+`tessdata_fast` 4.1.0 release into `~/.cache/pdf2zh/tessdata/4.1.0`; subsequent
+runs reuse it offline. Native-text PDFs do not trigger downloads.
+OCR uses the input language; `PDF2ZH_OCR_LANGUAGE=eng+deu` overrides it with
+Tesseract language codes. Set `TESSDATA_PREFIX` to use your own data without
+automatic downloads.
+
+PyMuPDF supplies the OCR engine; the optional extra adds Pooch for cached downloads.
+No separate Tesseract executable is required.
+OCR words are regrouped into paragraphs within detected layout regions before
+translation, with wrapped lines and soft hyphens joined. Translated paragraphs
+start at the median source font size and shrink to fit their original boxes;
+detected figures, tables, and standalone formulas remain untouched.
+The initial implementation targets white-background scans: partial scans on
+pages that already contain text are skipped, and handwritten text or inline
+equations may be recognized incorrectly. Precise mode is unchanged.
+
 ### 4.1 Advanced options
 
 Execute the translation command in the command line to generate the translated document `example-mono.pdf` and the bilingual document `example-dual.pdf` in the current working directory. Use Google as the default translation service. More support translation services can find [HERE](https://github.com/Byaidu/PDFMathTranslate/blob/main/docs/ADVANCED.md#services).

--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -87,6 +87,7 @@ def translate_patch(
     envs: Dict = None,
     prompt: Template = None,
     ignore_cache: bool = False,
+    ocr_pages: Optional[set[int]] = None,
     **kwarg: Any,
 ) -> None:
     rsrcmgr = PDFResourceManager()
@@ -132,6 +133,18 @@ def translate_patch(
                 pix.height, pix.width, 3
             )[:, :, ::-1]
             page_layout = model.predict(image, imgsz=int(pix.height / 32) * 32)[0]
+            if ocr_pages and pageno in ocr_pages:
+                from pdf2zh.ocr import translate_ocr_page
+
+                translate_ocr_page(
+                    doc_zh[pageno],
+                    page_layout,
+                    device.translator,
+                    noto,
+                    thread,
+                    cancellation_event,
+                )
+                continue
             # kdtree 是不可能 kdtree 的，不如直接渲染成图片，用空间换时间
             box = np.ones((pix.height, pix.width))
             h, w = box.shape
@@ -168,6 +181,97 @@ def translate_patch(
     return obj_patch
 
 
+def _ocr_tessdata(language):
+    """Use explicit local data, or download requested languages once on demand."""
+    if not re.fullmatch(r"[A-Za-z0-9_]+(?:\+[A-Za-z0-9_]+)*", language):
+        raise ValueError("Invalid OCR language; use Tesseract codes such as eng+deu")
+    if tessdata := os.environ.get("TESSDATA_PREFIX"):
+        return tessdata
+    try:
+        import pooch
+    except ImportError as exc:
+        raise RuntimeError(
+            "Automatic OCR downloads require pip install 'pdf2zh[ocr]'. "
+            "Alternatively, set TESSDATA_PREFIX to existing language data."
+        ) from exc
+    cache = Path.home() / ".cache/pdf2zh/tessdata/4.1.0"
+    for code in dict.fromkeys(language.split("+")):
+        filename = f"{code}.traineddata"
+        try:
+            pooch.retrieve(
+                url=f"https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/4.1.0/{filename}",
+                known_hash=None,
+                fname=filename,
+                path=cache,
+                downloader=pooch.HTTPDownloader(timeout=60),
+            )
+        except (requests.RequestException, OSError) as exc:
+            raise RuntimeError(
+                f"Could not download OCR data for '{code}'. Check the language code "
+                "and network connection, or set TESSDATA_PREFIX to local data."
+            ) from exc
+    return str(cache)
+
+
+def _ocr_pages(doc, pages, lang_in, cancellation_event):
+    """Add a text layer only to selected image-only pages in the working copy."""
+    language = os.environ.get("PDF2ZH_OCR_LANGUAGE") or {
+        "en": "eng",
+        "zh": "chi_sim",
+        "zh-cn": "chi_sim",
+        "zh-tw": "chi_tra",
+        "ja": "jpn",
+        "ko": "kor",
+        "de": "deu",
+        "fr": "fra",
+        "es": "spa",
+        "it": "ita",
+        "pt": "por",
+        "ru": "rus",
+    }.get(lang_in.lower(), lang_in or "eng")
+    ocr_pages = set()
+    tessdata = None
+    for pageno in range(len(doc)):
+        if cancellation_event and cancellation_event.is_set():
+            raise CancelledError("task cancelled")
+        if pages and pageno not in pages:
+            continue
+        page = doc[pageno]
+        # ponytail: image-only pages; partial scans need region-level OCR later.
+        if page.get_text().strip() or not page.get_image_info():
+            continue
+        logger.info("OCR page %d (%s)", pageno + 1, language)
+        if tessdata is None:
+            tessdata = _ocr_tessdata(language)
+        try:
+            data = page.get_pixmap(dpi=300, alpha=False, annots=False).pdfocr_tobytes(
+                language=language,
+                tessdata=tessdata,
+            )
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"OCR failed on page {pageno + 1} using '{language}' data in {tessdata}. "
+                "Check the language data and any TESSDATA_PREFIX override. "
+                "Use PDF2ZH_OCR_LANGUAGE to override the OCR language."
+            ) from exc
+        with Document(stream=data) as recognized:
+            if not recognized[0].get_text().strip():
+                logger.warning("OCR found no text on page %d", pageno + 1)
+                continue
+            contents = doc.get_new_xref()
+            doc.update_object(contents, "<<>>")
+            doc.update_stream(contents, b"")
+            page.set_contents(contents)
+            page.show_pdf_page(
+                page.rect * page.derotation_matrix,
+                recognized,
+                0,
+                rotate=page.rotation,
+            )
+        ocr_pages.add(pageno)
+    return ocr_pages
+
+
 def translate_stream(
     stream: bytes,
     pages: Optional[list[int]] = None,
@@ -197,6 +301,7 @@ def translate_stream(
     stream = io.BytesIO()
     doc_en.save(stream)
     doc_zh = Document(stream=stream)
+    ocr_pages = _ocr_pages(doc_zh, pages, lang_in, cancellation_event)
     page_count = doc_zh.page_count
     # font_list = [("GoNotoKurrent-Regular.ttf", font_path), ("tiro", None)]
     font_id = {}

--- a/pdf2zh/ocr.py
+++ b/pdf2zh/ocr.py
@@ -1,0 +1,161 @@
+"""Paragraph reconstruction and bounded typesetting for OCR pages."""
+
+import asyncio
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from html import escape
+from statistics import median
+
+from pymupdf import Archive, Document, Rect, TEXTFLAGS_DICT, TEXT_PRESERVE_IMAGES
+from tenacity import retry, wait_fixed
+
+
+def ocr_paragraphs(page, detection):
+    """Group OCR words by layout region, then join lines in reading order."""
+    regions = [
+        (Rect(*box.xyxy), detection.names[int(box.cls)], box.conf)
+        for box in detection.boxes
+    ]
+    line_sizes = {
+        (block["number"], i): median(span["size"] for span in line["spans"])
+        for block in page.get_text(
+            "dict", flags=TEXTFLAGS_DICT & ~TEXT_PRESERVE_IMAGES
+        )["blocks"]
+        for i, line in enumerate(block.get("lines", []))
+        if line["spans"]
+    }
+    groups = defaultdict(list)
+    protected = {"figure", "table", "isolate_formula", "formula_caption"}
+    for word in page.get_text("words"):
+        rect = Rect(word[:4]) * page.rotation_matrix
+        if rect.is_empty or not word[4].strip():
+            continue
+        center = (rect.tl + rect.br) / 2
+        if any(center in box and name in protected for box, name, _ in regions):
+            continue
+        matches = [
+            ((Rect(rect) & box).get_area(), confidence, i)
+            for i, (box, _, confidence) in enumerate(regions)
+        ]
+        overlap, _, region = max(matches, default=(0, 0, -1))
+        if overlap and regions[region][1] == "abandon":
+            continue
+        key = region if overlap else ("unassigned", word[5])
+        groups[key].append((rect, word[4], word[5:7]))
+
+    paragraphs = []
+    for words in groups.values():
+        line_height = median(w[0].height for w in words)
+        ordered = []
+        for word in sorted(words, key=lambda w: (w[0].y0 + w[0].y1, w[0].x0)):
+            center = (word[0].y0 + word[0].y1) / 2
+            if (
+                not ordered
+                or abs(center - median((w[0].y0 + w[0].y1) / 2 for w in ordered[-1]))
+                > line_height * 0.5
+            ):
+                ordered.append([])
+            ordered[-1].append(word)
+        left = min(w[0].x0 for w in words)
+        chunks = []
+        for line in ordered:
+            line.sort(key=lambda w: w[0].x0)
+            bounds = Rect(line[0][0])
+            for word in line[1:]:
+                bounds |= word[0]
+            if chunks:
+                previous = chunks[-1][-1][0]
+                if (
+                    bounds.y0 - previous.y1 > line_height * 0.8
+                    or bounds.x0 > left + line_height * 0.8
+                    or bounds.x0 >= previous.x1
+                    or bounds.x1 <= previous.x0
+                ):
+                    chunks.append([])
+            else:
+                chunks.append([])
+            chunks[-1].append((bounds, " ".join(w[1] for w in line), line))
+        for chunk in chunks:
+            bounds = Rect(chunk[0][0])
+            text = ""
+            source = []
+            sizes = []
+            for rect, line, words in chunk:
+                bounds |= rect
+                # ponytail: a lowercase continuation treats an end-of-line hyphen as soft.
+                if text.endswith("-") and line[:1].islower():
+                    text = text[:-1] + line
+                else:
+                    text += (" " if text else "") + line
+                source.extend(w[0] for w in words)
+                sizes.extend(
+                    line_sizes.get(tuple(w[2]), w[0].height * 0.85) for w in words
+                )
+            size = median(sizes)
+            bounds.y1 = min(page.rect.y1, max(bounds.y1, bounds.y0 + size * 1.25))
+            paragraphs.append((bounds, text, size, source))
+    # OCR glyph boxes can overlap the next paragraph by a few points.
+    for i, (above, _, _, _) in enumerate(paragraphs):
+        for below, _, _, _ in paragraphs[i + 1 :]:
+            a, b = sorted((above, below), key=lambda r: r.y0)
+            overlap = min(a.x1, b.x1) - max(a.x0, b.x0)
+            if a.y0 < b.y0 < a.y1 and overlap > min(a.width, b.width) / 2:
+                boundary = (a.y1 + b.y0) / 2
+                a.y1, b.y0 = boundary - 0.5, boundary + 0.5
+    return paragraphs
+
+
+def translate_ocr_page(
+    page, detection, translator, font, thread, cancellation_event=None
+):
+    paragraphs = ocr_paragraphs(page, detection)
+    if not paragraphs:
+        return
+
+    @retry(wait=wait_fixed(1))
+    def translate(paragraph):
+        if cancellation_event and cancellation_event.is_set():
+            raise asyncio.CancelledError("task cancelled")
+        return translator.translate(paragraph[1])
+
+    with ThreadPoolExecutor(max_workers=max(1, thread)) as executor:
+        translations = list(executor.map(translate, paragraphs))
+    if not any(text.strip() for text in translations):
+        return
+    archive = Archive((font.buffer, "ocr.ttf"))
+    with Document() as overlay:
+        target = overlay.new_page(width=page.rect.width, height=page.rect.height)
+        for (_, _, _, words), text in zip(paragraphs, translations):
+            if text.strip():
+                for rect in words:
+                    target.draw_rect(
+                        rect + (-0.5, -0.5, 0.5, 0.5), color=None, fill=(1, 1, 1)
+                    )
+        for (bounds, _, size, _), text in zip(paragraphs, translations):
+            if not text.strip():
+                continue
+            centered = any(
+                detection.names[int(box.cls)] == "title"
+                and (Rect(*box.xyxy) & bounds).get_area() > bounds.get_area() / 2
+                for box in detection.boxes
+            )
+            align = "center" if centered else "justify"
+            css = (
+                "@font-face {font-family:ocr;src:url(ocr.ttf);}"
+                f"body {{font-family:ocr;font-size:{size}pt;line-height:1.2;margin:0;}}"
+                f"p {{margin:0;overflow-wrap:break-word;text-align:{align};}}"
+            )
+            spare, _ = target.insert_htmlbox(
+                bounds, f"<p>{escape(text)}</p>", css=css, archive=archive, scale_low=0
+            )
+            if spare < 0:
+                raise RuntimeError("OCR translation could not fit its paragraph box")
+        # Remove the invisible OCR layer, keeping source pixels and annotations.
+        links = page.get_links()
+        page.add_redact_annot(page.rect * page.derotation_matrix, fill=False)
+        page.apply_redactions(images=0, graphics=0, text=0)
+        for link in links:
+            page.insert_link(link)
+        page.show_pdf_page(
+            page.rect * page.derotation_matrix, overlay, 0, rotate=page.rotation
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+ocr = [
+    "pooch>=1.8,<2",  # first-use downloads for PyMuPDF's built-in OCR
+]
 backend = [
     "flask",
     "celery",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "onnx",
     "onnxruntime",
     "opencv-python-headless",
-    "tencentcloud-sdk-python-tmt",
+    "tencentcloud-sdk-python-tmt==3.1.70",  # newer releases remove TextTranslate
     "pdfminer-six==20250416",
     "gradio_pdf>=0.0.21",
     "pikepdf",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4,7 +4,7 @@ import unittest
 
 
 class TestCliVersion(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         for module_name in [
             "pdf2zh",
             "pdf2zh.pdf2zh",
@@ -12,6 +12,9 @@ class TestCliVersion(unittest.TestCase):
             "pdf2zh.doclayout",
         ]:
             sys.modules.pop(module_name, None)
+
+    def tearDown(self):
+        self.setUp()
 
     def test_importing_package_does_not_eagerly_load_translation_pipeline(self):
         pkg = importlib.import_module("pdf2zh")

--- a/test/test_ocr.py
+++ b/test/test_ocr.py
@@ -1,0 +1,283 @@
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+from pathlib import Path
+
+import numpy as np
+import pymupdf
+
+_CACHE_HOME = tempfile.mkdtemp()
+
+
+def _expanduser(path):
+    return _CACHE_HOME if path == "~" else path
+
+
+with patch("os.path.expanduser", side_effect=_expanduser):
+    import pdf2zh.high_level as high_level
+    from pdf2zh.high_level import _ocr_pages
+from pdf2zh.doclayout import YoloResult
+
+
+def _source_pdf():
+    doc = pymupdf.open()
+
+    def add_image(page):
+        pixmap = pymupdf.Pixmap(pymupdf.csRGB, (0, 0, 24, 16), False)
+        pixmap.clear_with(255)
+        page.insert_image(page.rect, pixmap=pixmap)
+
+    target = doc.new_page(width=120, height=80)
+    add_image(target)
+    target.insert_link(
+        {
+            "kind": pymupdf.LINK_URI,
+            "from": pymupdf.Rect(5, 5, 25, 15),
+            "uri": "https://example.com",
+        }
+    )
+
+    unselected = doc.new_page(width=120, height=80)
+    add_image(unselected)
+
+    native = doc.new_page(width=120, height=80)
+    native.insert_text((10, 20), "native text")
+
+    doc.new_page(width=120, height=80)
+
+    existing = doc.new_page(width=120, height=80)
+    add_image(existing)
+    existing.insert_text((10, 20), "existing OCR")
+    return doc.tobytes()
+
+
+def _recognized_pdf():
+    doc = pymupdf.open()
+    page = doc.new_page(width=120, height=80)
+    page.insert_text((10, 20), "recognized text")
+    return doc.tobytes()
+
+
+def _scan_streams():
+    def add_text(page, render_mode=0):
+        page.insert_text(
+            (10, 25), "body", fontname="helv", fontsize=6, render_mode=render_mode
+        )
+        page.insert_text(
+            (30, 25), " words", fontname="helv", fontsize=18, render_mode=render_mode
+        )
+        page.insert_text(
+            (10, 65), "protected", fontname="helv", fontsize=18, render_mode=render_mode
+        )
+
+    with pymupdf.open() as artwork:
+        add_text(artwork.new_page(width=120, height=80))
+        image = artwork[0].get_pixmap(alpha=False)
+        with pymupdf.open() as scan:
+            scan_page = scan.new_page(width=120, height=80)
+            scan_page.insert_image(scan_page.rect, pixmap=image)
+            source = scan.tobytes()
+            with pymupdf.open() as recognized:
+                recognized_page = recognized.new_page(width=120, height=80)
+                recognized_page.insert_image(recognized_page.rect, pixmap=image)
+                add_text(recognized_page, render_mode=3)
+                return source, recognized.tobytes()
+
+
+def _pixels(page):
+    pixmap = page.get_pixmap(alpha=False, annots=False)
+    return np.frombuffer(pixmap.samples, np.uint8).reshape(
+        pixmap.height, pixmap.width, pixmap.n
+    )
+
+
+class TestOCRPages(unittest.TestCase):
+    def test_selection_skips_native_blank_and_existing_layers(self):
+        source = _source_pdf()
+        recognized = _recognized_pdf()
+
+        with pymupdf.open(stream=source) as doc:
+            page_xrefs = [page.xref for page in doc]
+            target_rect = doc[0].rect
+            with patch.object(
+                high_level, "_ocr_tessdata", return_value="/tmp/tessdata"
+            ) as tessdata:
+                with patch.object(
+                    pymupdf.Pixmap, "pdfocr_tobytes", return_value=recognized
+                ) as ocr:
+                    result = _ocr_pages(doc, [0, 2, 3, 4], "en", None)
+
+            self.assertEqual(result, {0})
+            tessdata.assert_called_once_with("eng")
+            ocr.assert_called_once_with(language="eng", tessdata="/tmp/tessdata")
+            self.assertEqual([page.xref for page in doc], page_xrefs)
+            self.assertEqual(doc[0].rect, target_rect)
+            self.assertEqual(doc[0].get_text().strip(), "recognized text")
+            self.assertEqual(doc[0].get_links()[0]["uri"], "https://example.com")
+            self.assertEqual(doc[1].get_text().strip(), "")
+            self.assertEqual(doc[2].get_text().strip(), "native text")
+            self.assertEqual(doc[3].get_text().strip(), "")
+            self.assertEqual(doc[4].get_text().strip(), "existing OCR")
+
+    def test_ocr_failure_has_actionable_error(self):
+        with pymupdf.open(stream=_source_pdf()) as doc:
+            with patch.object(
+                high_level, "_ocr_tessdata", return_value="/tmp/tessdata"
+            ):
+                with patch.object(
+                    pymupdf.Pixmap,
+                    "pdfocr_tobytes",
+                    side_effect=RuntimeError("tesseract unavailable"),
+                ):
+                    with self.assertRaisesRegex(
+                        RuntimeError, "OCR failed on page 1.*TESSDATA_PREFIX"
+                    ):
+                        _ocr_pages(doc, [0], "en", None)
+
+    def test_cancellation_stops_before_ocr(self):
+        event = asyncio.Event()
+        event.set()
+        with pymupdf.open(stream=_source_pdf()) as doc:
+            with patch.object(high_level, "_ocr_tessdata") as tessdata:
+                with patch.object(pymupdf.Pixmap, "pdfocr_tobytes") as ocr:
+                    with self.assertRaises(asyncio.CancelledError):
+                        _ocr_pages(doc, [0], "en", event)
+                    tessdata.assert_not_called()
+                    ocr.assert_not_called()
+
+    def test_no_candidate_does_not_resolve_tessdata(self):
+        with pymupdf.open(stream=_source_pdf()) as doc:
+            with patch.object(high_level, "_ocr_tessdata") as tessdata:
+                with patch.object(pymupdf.Pixmap, "pdfocr_tobytes") as ocr:
+                    self.assertEqual(_ocr_pages(doc, [2, 3, 4], "en", None), set())
+                    tessdata.assert_not_called()
+                    ocr.assert_not_called()
+
+    def test_tessdata_explicit_override_skips_download(self):
+        with patch.dict(os.environ, {"TESSDATA_PREFIX": "/manual/tessdata"}):
+            with patch.dict(sys.modules, {"pooch": None}):
+                self.assertEqual(
+                    high_level._ocr_tessdata("eng+deu"), "/manual/tessdata"
+                )
+
+    def test_tessdata_rejects_invalid_language(self):
+        with patch.dict(os.environ, {"TESSDATA_PREFIX": ""}):
+            for language in ("../eng", "eng/foo", "eng+"):
+                with self.assertRaisesRegex(ValueError, "Invalid OCR language"):
+                    high_level._ocr_tessdata(language)
+
+    def test_tessdata_missing_optional_dependency_is_actionable(self):
+        with tempfile.TemporaryDirectory() as home:
+            with patch.dict(os.environ, {"TESSDATA_PREFIX": ""}):
+                with patch.object(high_level.Path, "home", return_value=Path(home)):
+                    with patch.dict(sys.modules, {"pooch": None}):
+                        with self.assertRaisesRegex(RuntimeError, r"pdf2zh\[ocr\]"):
+                            high_level._ocr_tessdata("eng")
+
+    def test_tessdata_downloads_each_language_and_reuses_cache(self):
+        try:
+            import pooch
+        except ImportError:
+            self.skipTest("pooch optional dependency is unavailable")
+
+        with tempfile.TemporaryDirectory() as home:
+            downloads = []
+
+            def download(url, output_file, _pooch, check_only=False):
+                downloads.append(url)
+                Path(output_file).write_bytes(b"traineddata")
+
+            downloader = Mock(side_effect=download)
+            with patch.dict(os.environ, {"TESSDATA_PREFIX": ""}):
+                with patch.object(high_level.Path, "home", return_value=Path(home)):
+                    with patch.object(
+                        pooch, "HTTPDownloader", return_value=downloader
+                    ) as make_downloader:
+                        downloader.side_effect = high_level.requests.ConnectionError(
+                            "offline"
+                        )
+                        with self.assertRaisesRegex(
+                            RuntimeError, "Could not download OCR data"
+                        ):
+                            high_level._ocr_tessdata("eng")
+                        self.assertFalse(list(Path(home).rglob("*.traineddata")))
+                        downloader.reset_mock()
+                        downloader.side_effect = download
+                        cache = high_level._ocr_tessdata("eng+deu")
+                        self.assertEqual(
+                            cache,
+                            str(Path(home) / ".cache/pdf2zh/tessdata/4.1.0"),
+                        )
+                        self.assertEqual(cache, high_level._ocr_tessdata("eng+deu"))
+
+            self.assertEqual(
+                downloads,
+                [
+                    "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/4.1.0/eng.traineddata",
+                    "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/4.1.0/deu.traineddata",
+                ],
+            )
+            self.assertEqual(downloader.call_count, 2)
+            self.assertEqual(make_downloader.call_args.kwargs, {"timeout": 60})
+
+    def test_translate_stream_ocr_masks_body_and_preserves_source(self):
+        source, recognized = _scan_streams()
+        layout = YoloResult(
+            [
+                np.array([0, 42, 120, 80, 0.95, 0]),
+                np.array([0, 0, 120, 42, 0.90, 1]),
+            ],
+            ["figure", "text"],
+        )
+        model = Mock()
+        model.predict.return_value = [layout]
+        calls = []
+
+        def translate(text):
+            calls.append(text)
+            return "X"
+
+        with (
+            patch.object(high_level, "download_remote_fonts", return_value=None),
+            patch.object(high_level, "NOTO_NAME", "helv"),
+            patch.object(high_level, "_ocr_tessdata", return_value="/tmp/tessdata"),
+            patch.object(pymupdf.Pixmap, "pdfocr_tobytes", return_value=recognized),
+            patch(
+                "pdf2zh.translator.GoogleTranslator.translate", side_effect=translate
+            ),
+        ):
+            mono, dual = high_level.translate_stream(
+                source,
+                lang_in="en",
+                lang_out="en",
+                service="google",
+                thread=1,
+                model=model,
+                skip_subset_fonts=True,
+            )
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("body", calls[0])
+        self.assertIn("words", calls[0])
+        self.assertNotIn("{v", calls[0])
+        self.assertNotIn("protected", calls[0])
+        with (
+            pymupdf.open(stream=source) as source_doc,
+            pymupdf.open(stream=mono) as mono_doc,
+            pymupdf.open(stream=dual) as dual_doc,
+        ):
+            self.assertEqual(mono_doc[0].get_text().strip(), "X")
+            self.assertNotIn("protected", mono_doc[0].get_text())
+            source_pixels = _pixels(source_doc[0])
+            mono_pixels = _pixels(mono_doc[0])
+            self.assertTrue(np.array_equal(source_pixels, _pixels(dual_doc[0])))
+            self.assertTrue(
+                np.array_equal(source_pixels[45:72, 10:85], mono_pixels[45:72, 10:85])
+            )
+            source_crop = source_pixels[5:32, 35:80]
+            mono_crop = mono_pixels[5:32, 35:80]
+            self.assertGreater(np.count_nonzero(source_crop[:, :, :3] < 128), 0)
+            self.assertEqual(np.count_nonzero(mono_crop[:, :, :3] < 200), 0)

--- a/test/test_ocr_layout.py
+++ b/test/test_ocr_layout.py
@@ -1,0 +1,131 @@
+import unittest
+
+import numpy as np
+import pymupdf
+
+from pdf2zh.doclayout import YoloResult
+from pdf2zh.ocr import ocr_paragraphs, translate_ocr_page
+
+
+def _pixels(page):
+    pixmap = page.get_pixmap(alpha=False, annots=False)
+    return np.frombuffer(pixmap.samples, np.uint8).reshape(
+        pixmap.height, pixmap.width, pixmap.n
+    )
+
+
+class TestOCRLayout(unittest.TestCase):
+    def test_interleaved_columns_group_by_detection_region(self):
+        doc = pymupdf.open()
+        page = doc.new_page(width=200, height=100)
+        for text, point in (
+            ("left one", (10, 20)),
+            ("right one", (110, 20)),
+            ("left two", (10, 40)),
+            ("right two", (110, 40)),
+        ):
+            page.insert_text(point, text, fontsize=10, render_mode=3)
+        detection = YoloResult(
+            [
+                np.array([0, 0, 95, 100, 0.9, 0]),
+                np.array([100, 0, 200, 100, 0.9, 0]),
+            ],
+            ["text"],
+        )
+
+        paragraphs = ocr_paragraphs(page, detection)
+
+        self.assertEqual(
+            [paragraph[1] for paragraph in paragraphs],
+            ["left one left two", "right one right two"],
+        )
+        self.assertLess(paragraphs[0][0].x1, paragraphs[1][0].x0)
+
+    def test_fragmented_lines_rejoin_soft_hyphen_and_use_median_font(self):
+        doc = pymupdf.open()
+        page = doc.new_page(width=200, height=120)
+        for text, point, size in (
+            ("frag", (10, 20), 10),
+            ("mented", (35, 20), 10),
+            ("fertil-", (10, 40), 10),
+            ("izer", (10, 60), 10),
+            ("outlier", (10, 88), 28),
+        ):
+            page.insert_text(point, text, fontsize=size, render_mode=3)
+        detection = YoloResult([np.array([0, 0, 200, 120, 0.9, 0])], ["text"])
+
+        paragraphs = ocr_paragraphs(page, detection)
+
+        self.assertEqual(len(paragraphs), 1)
+        self.assertEqual(paragraphs[0][1], "frag mented fertilizer outlier")
+        self.assertAlmostEqual(paragraphs[0][2], 10, delta=0.1)
+
+    def test_translation_fits_escaped_text_and_preserves_figure_pixels(self):
+        artwork = pymupdf.open()
+        artwork_page = artwork.new_page(width=220, height=140)
+        artwork_page.draw_rect(
+            pymupdf.Rect(125, 70, 215, 135), color=None, fill=(1, 0, 0)
+        )
+        artwork_page.insert_text((10, 25), "body text", fontsize=18)
+        artwork_page.insert_text((10, 100), "lower", fontsize=10)
+        image = artwork_page.get_pixmap(alpha=False)
+
+        doc = pymupdf.open()
+        page = doc.new_page(width=220, height=140)
+        page.insert_image(page.rect, pixmap=image)
+        page.insert_text((10, 25), "body text", fontsize=18, render_mode=3)
+        page.insert_text((10, 100), "lower", fontsize=10, render_mode=3)
+        page.insert_text((135, 105), "figure secret", fontsize=10, render_mode=3)
+        detection = YoloResult(
+            [
+                np.array([0, 0, 115, 65, 0.9, 1]),
+                np.array([115, 0, 220, 140, 0.9, 0]),
+            ],
+            ["figure", "text"],
+        )
+        paragraphs = ocr_paragraphs(page, detection)
+        body = next(
+            paragraph for paragraph in paragraphs if paragraph[1] == "body text"
+        )
+        lower = next(paragraph for paragraph in paragraphs if paragraph[1] == "lower")
+        before = _pixels(page)[70:135, 125:215].copy()
+
+        class Translator:
+            def __init__(self):
+                self.calls = []
+
+            def translate(self, text):
+                self.calls.append(text)
+                return "<tag>& " * (30 if text == "body text" else 1)
+
+        translator = Translator()
+        translate_ocr_page(page, detection, translator, pymupdf.Font("helv"), 1)
+
+        self.assertEqual(translator.calls, ["body text", "lower"])
+        self.assertTrue(np.array_equal(before, _pixels(page)[70:135, 125:215]))
+        blocks = [
+            block for block in page.get_text("dict")["blocks"] if block["type"] == 0
+        ]
+        body_block = next(
+            block
+            for block in blocks
+            if "<tag>"
+            in "".join(
+                span["text"] for line in block["lines"] for span in line["spans"]
+            )
+        )
+        body_text = "".join(
+            span["text"] for line in body_block["lines"] for span in line["spans"]
+        )
+        self.assertIn("<tag>&", body_text)
+        body_rect = pymupdf.Rect(body_block["bbox"])
+        self.assertLessEqual(body_rect.x1, body[0].x1 + 0.5)
+        self.assertLessEqual(body_rect.y1, lower[0].y0)
+        self.assertLess(
+            max(span["size"] for line in body_block["lines"] for span in line["spans"]),
+            body[2],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds experimental OCR support to fast mode so image-only PDF pages can be translated without preprocessing them in another tool. PyMuPDF supplies the local OCR engine; the new `[ocr]` extra downloads and caches Tesseract language data on first use, with language and local-data overrides available.

Recognized words are regrouped within detected layout regions before translation, joining wrapped lines and soft hyphens. Translated paragraphs start at the median source font size and shrink to fit their original bounds. Detected figures, tables, and standalone formulas are preserved, and bilingual output retains the original source pages.

This initial implementation targets white-background, image-only scans. Pages with existing text or OCR layers are skipped; handwriting and inline equations may be recognized incorrectly. Precise mode is unchanged.

Validation: 70 OCR, converter, layout, and kernel regression tests passed before the final documentation change. Includes coverage for cached downloads, page selection, source preservation, two-column grouping, and bounded typesetting. A live external Chinese translation preview was not completed.
