### PR TITLE
fix: import Tencent SDK lazily so other engines are not broken by incompatible SDK

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -29,10 +29,9 @@ logger = logging.getLogger(__name__)
 def _tencent_translate_imports():
     """Import the Tencent TMT bindings on demand.
 
-    tencentcloud-sdk-python-tmt releases newer than 3.1 removed
-    TextTranslateRequest/TextTranslateResponse. Importing them at module
-    load used to break every other translation engine on environments
-    where such a version is installed.
+    Importing these optional bindings at module load would prevent all
+    translation engines from loading when the Tencent SDK is missing
+    or no longer exposes the TextTranslate API.
     """
     try:
         from tencentcloud.common import credential
@@ -44,8 +43,8 @@ def _tencent_translate_imports():
     except ImportError as exc:
         raise ImportError(
             "tencentcloud-sdk-python-tmt is missing or incompatible; "
-            "install it with a version below 3.1 to use the Tencent engine "
-            "(e.g. `pip install 'tencentcloud-sdk-python-tmt<3.1'`)"
+            "install the version pinned by pdf2zh to use the Tencent engine "
+            "(e.g. `pip install 'tencentcloud-sdk-python-tmt==3.1.70'`)"
         ) from exc
     return credential, TextTranslateRequest, TextTranslateResponse, TmtClient
 

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -14,12 +14,6 @@ import requests
 import xinference_client
 from azure.ai.translation.text import TextTranslationClient
 from azure.core.credentials import AzureKeyCredential
-from tencentcloud.common import credential
-from tencentcloud.tmt.v20180321.models import (
-    TextTranslateRequest,
-    TextTranslateResponse,
-)
-from tencentcloud.tmt.v20180321.tmt_client import TmtClient
 
 from pdf2zh.cache import TranslationCache
 from pdf2zh.config import ConfigManager
@@ -30,6 +24,30 @@ from tenacity import stop_after_attempt
 from tenacity import wait_exponential
 
 logger = logging.getLogger(__name__)
+
+
+def _tencent_translate_imports():
+    """Import the Tencent TMT bindings on demand.
+
+    tencentcloud-sdk-python-tmt releases newer than 3.1 removed
+    TextTranslateRequest/TextTranslateResponse. Importing them at module
+    load used to break every other translation engine on environments
+    where such a version is installed.
+    """
+    try:
+        from tencentcloud.common import credential
+        from tencentcloud.tmt.v20180321.models import (
+            TextTranslateRequest,
+            TextTranslateResponse,
+        )
+        from tencentcloud.tmt.v20180321.tmt_client import TmtClient
+    except ImportError as exc:
+        raise ImportError(
+            "tencentcloud-sdk-python-tmt is missing or incompatible; "
+            "install it with a version below 3.1 to use the Tencent engine "
+            "(e.g. `pip install 'tencentcloud-sdk-python-tmt<3.1'`)"
+        ) from exc
+    return credential, TextTranslateRequest, TextTranslateResponse, TmtClient
 
 
 def remove_control_characters(s):
@@ -763,6 +781,12 @@ class TencentTranslator(BaseTranslator):
     def __init__(
         self, lang_in, lang_out, model, envs=None, ignore_cache=False, **kwargs
     ):
+        (
+            credential,
+            TextTranslateRequest,
+            TextTranslateResponse,
+            TmtClient,
+        ) = _tencent_translate_imports()
         self.set_envs(envs)
         super().__init__(lang_in, lang_out, model)
         try:
@@ -783,7 +807,7 @@ class TencentTranslator(BaseTranslator):
 
     def _translate_chunk(self, text):
         self.req.SourceText = text
-        resp: TextTranslateResponse = self.client.TextTranslate(self.req)
+        resp = self.client.TextTranslate(self.req)
         return resp.TargetText
 
     def do_translate(self, text):

--- a/test/test_translator.py
+++ b/test/test_translator.py
@@ -234,14 +234,15 @@ class TestTencentLazyImport(unittest.TestCase):
         return _blocked
 
     def test_module_imports_without_tencent_sdk(self):
-        # Reload pdf2zh.translator with the Tencent SDK unimportable:
-        # a missing/incompatible SDK must not break other engines.
-        with mock.patch(
-            "builtins.__import__",
-            side_effect=self._block_tencent_imports(__import__),
-        ):
-            reloaded = importlib.reload(translator_module)
-        self.assertIsNotNone(reloaded.BaseTranslator)
+        # Restore the module namespace after reload so other tests keep
+        # using the same translator classes, regardless of test order.
+        with mock.patch.dict(translator_module.__dict__):
+            with mock.patch(
+                "builtins.__import__",
+                side_effect=self._block_tencent_imports(__import__),
+            ):
+                reloaded = importlib.reload(translator_module)
+                self.assertIsNotNone(reloaded.BaseTranslator)
 
     def test_tencent_translator_raises_informative_error_without_sdk(self):
         with mock.patch(
@@ -250,7 +251,8 @@ class TestTencentLazyImport(unittest.TestCase):
         ):
             with self.assertRaises(ImportError) as context:
                 translator_module.TencentTranslator("en", "zh", "", False)
-        self.assertIn("tencentcloud-sdk-python-tmt", str(context.exception))
+        self.assertIn("tencentcloud-sdk-python-tmt==3.1.70", str(context.exception))
+        self.assertIsInstance(context.exception.__cause__, ModuleNotFoundError)
 
 
 if __name__ == "__main__":

--- a/test/test_translator.py
+++ b/test/test_translator.py
@@ -1,10 +1,11 @@
+import importlib
 import unittest
 from textwrap import dedent
 from unittest import mock
 
 from ollama import ResponseError as OllamaResponseError
 
-from pdf2zh import cache
+from pdf2zh import cache, translator as translator_module
 from pdf2zh.config import ConfigManager
 from pdf2zh.translator import BaseTranslator, OllamaTranslator, OpenAIlikedTranslator
 
@@ -218,6 +219,38 @@ class TestOllamaTranslator(unittest.TestCase):
         self.assertEqual(
             excepted_not_retain_cot_content, only_removed_cot_content.strip()
         )
+
+
+class TestTencentLazyImport(unittest.TestCase):
+    """The Tencent SDK must only be imported when the engine is actually used."""
+
+    @staticmethod
+    def _block_tencent_imports(real_import):
+        def _blocked(name, *args, **kwargs):
+            if name == "tencentcloud" or name.startswith("tencentcloud."):
+                raise ModuleNotFoundError(name)
+            return real_import(name, *args, **kwargs)
+
+        return _blocked
+
+    def test_module_imports_without_tencent_sdk(self):
+        # Reload pdf2zh.translator with the Tencent SDK unimportable:
+        # a missing/incompatible SDK must not break other engines.
+        with mock.patch(
+            "builtins.__import__",
+            side_effect=self._block_tencent_imports(__import__),
+        ):
+            reloaded = importlib.reload(translator_module)
+        self.assertIsNotNone(reloaded.BaseTranslator)
+
+    def test_tencent_translator_raises_informative_error_without_sdk(self):
+        with mock.patch(
+            "builtins.__import__",
+            side_effect=self._block_tencent_imports(__import__),
+        ):
+            with self.assertRaises(ImportError) as context:
+                translator_module.TencentTranslator("en", "zh", "", False)
+        self.assertIn("tencentcloud-sdk-python-tmt", str(context.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`pdf2zh/translator.py` previously imported the Tencent TMT bindings at module load. A missing or incompatible Tencent SDK could therefore prevent every translation engine from loading, even when Tencent was not selected, as reported in #1167.

This PR imports the SDK on demand from `TencentTranslator.__init__`. Import failures are chained into an informative `ImportError` without blocking unrelated engines.

The recovery command recommends `tencentcloud-sdk-python-tmt==3.1.70`, matching the existing pin in `pyproject.toml`. It does not assume that every 3.1.x release lacks the TextTranslate API. The dependency pin itself is unchanged.

## Regression coverage

`test/test_translator.py` checks that:

- The translator module can reload while all Tencent SDK imports are blocked. The original module namespace is restored afterward to avoid leaking replacement classes into other tests.
- Selecting Tencent with a missing SDK raises an informative error containing the exact recovery pin and preserves the original `ModuleNotFoundError` as its cause.

## Validation

Initial PR validation, reported before the follow-up commit:

- `python -m pytest test/test_translator.py -q`: 11 passed.
- Black check: 2 files unchanged.
- `flake8 --ignore E203,E261,E501,W503,E741`: clean.
- The full suite was not run because document-layout dependencies were unavailable in that environment.

Follow-up validation on September 10, 2026:

- Three standalone unit checks of the updated import helper passed: missing SDK, incompatible SDK, and successful imports using mocked SDK bindings.
- The complete follow-up diff was inspected before updating the branch; changes are limited to the recovery diagnostic and lazy-import tests.
- The project test suite and linters were not rerun for the follow-up: the test environment could not resolve GitHub to obtain a checkout/dependencies. The standalone checks above are not a replacement for upstream CI.

Fixes #1167