### PR TITLE
Validate translate-from-URL fetches against SSRF (fixes #1188)

### DIFF
--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -6,6 +6,7 @@ import socket
 import uuid
 from asyncio import CancelledError
 from pathlib import Path
+from urllib.parse import urljoin
 import typing as T
 
 import gradio as gr
@@ -16,7 +17,7 @@ from string import Template
 import logging
 
 from pdf2zh import __version__
-from pdf2zh.high_level import translate
+from pdf2zh.high_level import translate, assert_public_http_url
 from pdf2zh.doclayout import ModelInstance
 from pdf2zh.config import ConfigManager
 from pdf2zh.translator import (
@@ -183,7 +184,22 @@ def download_with_limit(url: str, save_path: str, size_limit: int) -> str:
     """
     chunk_size = 1024
     total_size = 0
-    with requests.get(url, stream=True, timeout=10) as response:
+    # Re-validate every redirect hop so a public URL cannot redirect the
+    # server-side fetch to an internal address (SSRF).
+    for _ in range(6):
+        assert_public_http_url(url)
+        response = requests.get(url, stream=True, timeout=10, allow_redirects=False)
+        if response.is_redirect or response.is_permanent_redirect:
+            location = response.headers.get("Location")
+            response.close()
+            if not location:
+                raise gr.Error("Invalid redirect from URL")
+            url = urljoin(url, location)
+            continue
+        break
+    else:
+        raise gr.Error("Too many redirects")
+    with response:
         response.raise_for_status()
         content = response.headers.get("Content-Disposition")
         try:  # filename from header

--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import io
+import ipaddress
 import os
 import re
+import socket
 import sys
 import tempfile
 import logging
@@ -11,6 +13,7 @@ from asyncio import CancelledError
 from pathlib import Path
 from string import Template
 from typing import Any, BinaryIO, List, Optional, Dict
+from urllib.parse import urljoin, urlparse
 
 import numpy as np
 import requests
@@ -34,6 +37,54 @@ from babeldoc.assets.assets import get_font_and_metadata
 NOTO_NAME = "noto"
 
 logger = logging.getLogger(__name__)
+
+_MAX_URL_REDIRECTS = 5
+
+
+def assert_public_http_url(url: str) -> None:
+    """Reject non-http(s) URLs and URLs resolving to a non-public address.
+
+    pdf2zh fetches user-supplied URLs server-side (translating a document from a
+    link). Without this check that is a server-side request forgery primitive:
+    a caller can target loopback, private-range, link-local (cloud metadata),
+    or other internal addresses. Every address the host resolves to must be
+    global.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise PDFValueError("Only http/https URLs are allowed")
+    host = parsed.hostname
+    if not host:
+        raise PDFValueError("Invalid URL")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        addrinfo = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise PDFValueError("Could not resolve URL host") from e
+    for _family, _type, _proto, _canon, sockaddr in addrinfo:
+        ip = ipaddress.ip_address(sockaddr[0])
+        mapped = getattr(ip, "ipv4_mapped", None)
+        if mapped is not None:
+            ip = mapped
+        if not ip.is_global or ip.is_reserved:
+            raise PDFValueError("URL host resolves to a non-public address")
+
+
+def fetch_public_url(url: str, **kwargs) -> requests.Response:
+    """GET *url* with SSRF protection, re-validating every redirect hop."""
+    for _ in range(_MAX_URL_REDIRECTS + 1):
+        assert_public_http_url(url)
+        response = requests.get(url, allow_redirects=False, **kwargs)
+        if response.is_redirect or response.is_permanent_redirect:
+            location = response.headers.get("Location")
+            response.close()
+            if not location:
+                raise PDFValueError("Invalid redirect from URL")
+            url = urljoin(url, location)
+            continue
+        return response
+    raise PDFValueError("Too many redirects")
+
 
 noto_list = [
     "am",  # Amharic
@@ -445,7 +496,7 @@ def translate(
         ):
             print("Online files detected, downloading...")
             try:
-                r = requests.get(file, allow_redirects=True)
+                r = fetch_public_url(file)
                 if r.status_code == 200:
                     with tempfile.NamedTemporaryFile(
                         suffix=".pdf", delete=False


### PR DESCRIPTION
Fixes #1188.

## Problem

`download_with_limit` (`pdf2zh/gui.py`) and `translate()` (`pdf2zh/high_level.py`) fetch caller-supplied URLs server-side with no scheme/address validation, so a user can make the server request loopback, private-range, or link-local (cloud metadata) addresses and other internal services. `high_level` also follows redirects, so a public URL can bounce to an internal one. PDF responses are translated and returned to the caller.

## Change

- Add `assert_public_http_url(url)` in `high_level.py`: require an `http`/`https` scheme and that every address the host resolves to is globally routable (rejects loopback, private, link-local, reserved, and IPv4-mapped forms).
- Add `fetch_public_url(url, **kwargs)`: disables automatic redirects and re-validates each hop before following it.
- `high_level.translate` now uses `fetch_public_url`; `gui.download_with_limit` calls `assert_public_http_url` and follows redirects with the same re-validating loop.

Python's `ipaddress` already treats NAT64/6to4 transition forms as non-global, so no extra unwrapping is needed. Legitimate public PDF links (including ones that redirect) keep working.
